### PR TITLE
Fix #38: Store the original PEM certificate next to fingerprint

### DIFF
--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -17,11 +17,11 @@ curl --request POST \
 }'
 ```
 
-## Adding New Certificate Fingerprint
+## Adding New Certificate
 
-Whenever your TLS/SSL certificate is about to expire, you need to add a new replacement fingerprint into the database.
+Whenever your TLS/SSL certificate is about to expire, you need to add a new replacement certificate and associated fingerprint into the database.
 
-There are several ways to add a new fingerprint.
+There are several ways to add a new certificate.
 
 ### Fetching Certificate Based on Domain
 
@@ -29,7 +29,7 @@ You can let our systems do the heavy lifting and fetch the SSL certificate autom
 
 ```sh
 curl --request POST \
-  --url http://localhost:8080/admin/apps/mobile-app/fingerprints/auto \
+  --url http://localhost:8080/admin/apps/mobile-app/certificates/auto \
   --header 'Authorization: Basic YWRtaW46YWRtaW4=' \
   --header 'Content-Type: application/json' \
   --data '{
@@ -49,7 +49,7 @@ Call the following service to import the certificate (notice the `\n` symbols in
 
 ```sh
 curl --request POST \
-  --url http://localhost:8080/admin/apps/mobile-app/fingerprints/pem \
+  --url http://localhost:8080/admin/apps/mobile-app/certificates/pem \
   --header 'Authorization: Basic YWRtaW46YWRtaW4=' \
   --header 'Content-Type: application/json' \
   --data '{

--- a/docs/Database-Structure.md
+++ b/docs/Database-Structure.md
@@ -64,16 +64,17 @@ CREATE TABLE ssl_mobile_domain (
 | `domain`           | `VARCHAR(255)` | Host name of the domain, such as `mobile.wultra.com`.       |
 <!-- end -->
 
-<!-- begin database table ssl_mobile_fingerprint -->
-### SSL Certificate Fingerprints 
+<!-- begin database table ssl_certificate -->
+### SSL Certificate 
 
-Table with TLS/SSL certificate fingerprints that should be pinned in the mobile app.
+Table with TLS/SSL certificate and fingerprints that should be pinned in the mobile app.
 
 #### Schema
 
 ```sql
-CREATE TABLE ssl_mobile_fingerprint (
+CREATE TABLE ssl_certificate (
     id INTEGER PRIMARY KEY,
+    pem TEXT NOT NULL,
     fingerprint VARCHAR(255) NOT NULL,
     expires INTEGER NOT NULL,
     mobile_domain_id INTEGER NOT NULL
@@ -82,12 +83,13 @@ CREATE TABLE ssl_mobile_fingerprint (
 
 #### Columns
 
-| Column              | Type           | Description                                                               |
-|---------------------|----------------|---------------------------------------------------------------------------|
-| `id`                | `INTEGER`      | Primary key for the table, automatically incremented value.               |
-| `fingerprint`       | `VARCHAR(255)` | Value of the certificate fingerprint.                                     |
-| `expires`           | `INTEGER`      | Unix timestamp (seconds since Jan 1, 1970) of the certificate expiration. |
-| `mobile_domain_id`  | `INTEGER`      | Reference to related application domain in the `ssl_mobile_domain` table. |
+| Column             | Type           | Description                                                               |
+|--------------------|----------------|---------------------------------------------------------------------------|
+| `id`               | `INTEGER`      | Primary key for the table, automatically incremented value.               |
+| `pem`              | `TEXT`         | Original certificate value in PEM format.                                 |
+| `fingerprint`      | `VARCHAR(255)` | Value of the certificate fingerprint.                                     |
+| `expires`          | `INTEGER`      | Unix timestamp (seconds since Jan 1, 1970) of the certificate expiration. |
+| `mobile_domain_id` | `INTEGER`      | Reference to related application domain in the `ssl_mobile_domain` table. |
 <!-- end -->
 
 <!-- begin database table ssl_user -->
@@ -166,15 +168,15 @@ CREATE SEQUENCE IF NOT EXISTS ssl_mobile_domain_seq MAXVALUE 9999999999999 CACHE
 ```
 <!-- end -->
 
-<!-- begin database sequence ssl_mobile_fingerprint_seq -->
-### SSL Certificate Fingerprint Sequence
+<!-- begin database sequence ssl_certificate_seq -->
+### SSL Certificate Sequence
 
-Sequence responsible for SSL fingerprints autoincrements.
+Sequence responsible for SSL certificates and fingerprints autoincrements.
 
 #### Schema
 
 ```sql
-CREATE SEQUENCE IF NOT EXISTS ssl_mobile_fingerprint_seq MAXVALUE 9999999999999 CACHE 20;
+CREATE SEQUENCE IF NOT EXISTS ssl_certificates_seq MAXVALUE 9999999999999 CACHE 20;
 ```
 <!-- end -->
 

--- a/docs/db/changelog/changesets/mobile-utility-server/1.5.x/20230308-additional-cert-info.xml
+++ b/docs/db/changelog/changesets/mobile-utility-server/1.5.x/20230308-additional-cert-info.xml
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  ~ Wultra Mobile Utility Server
+  ~ Copyright (C) 2023  Wultra s.r.o.
+  ~
+  ~ This program is free software: you can redistribute it and/or modify
+  ~ it under the terms of the GNU Affero General Public License as
+  ~ published by the Free Software Foundation, either version 3 of the
+  ~ License, or (at your option) any later version.
+  ~
+  ~ This program is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  ~ GNU Affero General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Affero General Public License
+  ~ along with this program.  If not, see <https://www.gnu.org/licenses/>.
+  -->
+
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+         http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.10.xsd">
+
+    <changeSet id="1" author="Petr Dvorak" logicalFilePath="mobile-utility-server/1.5.x/20230308-additional-cert-info.xml">
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <columnExists tableName="ssl_mobile_fingerprint" columnName="pem"/>
+            </not>
+        </preConditions>
+        <comment>Create a new column to store the certificate in PEM format.</comment>
+        <addColumn tableName="ssl_mobile_fingerprint">
+            <column name="pem" type="text">
+                <constraints nullable="false"/>
+            </column>
+        </addColumn>
+        <rollback>
+            <dropColumn tableName="ssl_mobile_fingerprint" columnName="pem"/>
+        </rollback>
+    </changeSet>
+
+    <changeSet id="2" author="Petr Dvorak" logicalFilePath="mobile-utility-server/1.5.x/20230308-additional-cert-info.xml">
+        <comment>Rename the ssl_mobile_fingerprint table to ssl_certificate.</comment>
+        <renameTable oldTableName="ssl_mobile_fingerprint" newTableName="ssl_certificate"/>
+        <rollback>
+            <renameTable oldTableName="ssl_certificate" newTableName="ssl_mobile_fingerprint"/>
+        </rollback>
+    </changeSet>
+
+    <changeSet id="3" author="Petr Dvorak" logicalFilePath="mobile-utility-server/1.5.x/20230308-additional-cert-info.xml">
+        <comment>Rename the ssl_mobile_fingerprint_seq sequence to ssl_certificate_seq.</comment>
+        <renameSequence oldSequenceName="ssl_mobile_fingerprint_seq" newSequenceName="ssl_certificate_seq"/>
+        <rollback>
+            <renameSequence oldSequenceName="ssl_certificate_seq" newSequenceName="ssl_mobile_fingerprint_seq"/>
+        </rollback>
+    </changeSet>
+
+</databaseChangeLog>

--- a/docs/db/changelog/changesets/mobile-utility-server/1.5.x/db.changelog-version.xml
+++ b/docs/db/changelog/changesets/mobile-utility-server/1.5.x/db.changelog-version.xml
@@ -26,5 +26,6 @@
     <!-- 1.5.x -->
     <include file="20230227-initial-import.xml" relativeToChangelogFile="true" />
     <include file="20230306-add-user-schema.xml" relativeToChangelogFile="true" />
+    <include file="20230308-additional-cert-info.xml" relativeToChangelogFile="true"/>
 
 </databaseChangeLog>

--- a/src/main/java/com/wultra/app/mobileutilityserver/database/model/CertificateEntity.java
+++ b/src/main/java/com/wultra/app/mobileutilityserver/database/model/CertificateEntity.java
@@ -25,27 +25,30 @@ import javax.persistence.*;
 
 
 /**
- * Entity representing an SSL pinning fingerprint.
+ * Entity representing an SSL pinning certificate.
  *
  * @author Petr Dvorak, petr@wultra.com
  */
 @Entity
-@Table(name = "ssl_mobile_fingerprint")
-public class CertificateFingerprintEntity {
+@Table(name = "ssl_certificate")
+public class CertificateEntity {
 
     @Id
     @Column(name = "id")
     @GenericGenerator(
-            name = "ssl_mobile_fingerprint",
+            name = "ssl_certificate",
             strategy = "org.hibernate.id.enhanced.SequenceStyleGenerator",
             parameters = {
-                    @Parameter(name = "sequence_name", value = "ssl_mobile_fingerprint_seq"),
+                    @Parameter(name = "sequence_name", value = "ssl_certificate_seq"),
                     @Parameter(name = "initial_value", value = "1"),
                     @Parameter(name = "increment_size", value = "1")
             }
     )
-    @GeneratedValue(generator = "ssl_mobile_fingerprint")
+    @GeneratedValue(generator = "ssl_certificate")
     private Long id;
+
+    @Column(name = "pem")
+    private String pem;
 
     @Column(name = "fingerprint")
     private String fingerprint;
@@ -71,6 +74,22 @@ public class CertificateFingerprintEntity {
      */
     public void setId(Long id) {
         this.id = id;
+    }
+
+    /**
+     * Get certificate in PEM format.
+     * @return Certificate in PEM format.
+     */
+    public String getPem() {
+        return pem;
+    }
+
+    /**
+     * Set certificate in PEM format.
+     * @param pem Certificate in PEM format.
+     */
+    public void setPem(String pem) {
+        this.pem = pem;
     }
 
     /**

--- a/src/main/java/com/wultra/app/mobileutilityserver/database/model/MobileDomainEntity.java
+++ b/src/main/java/com/wultra/app/mobileutilityserver/database/model/MobileDomainEntity.java
@@ -57,7 +57,7 @@ public class MobileDomainEntity {
 
     @ToString.Exclude
     @OneToMany(mappedBy = "domain", cascade = CascadeType.ALL, orphanRemoval=true)
-    private final List<CertificateFingerprintEntity> fingerprints = new ArrayList<>();
+    private final List<CertificateEntity> certificates = new ArrayList<>();
 
     /**
      * Get ID.
@@ -107,7 +107,7 @@ public class MobileDomainEntity {
         this.app = app;
     }
 
-    public List<CertificateFingerprintEntity> getFingerprints() {
-        return fingerprints;
+    public List<CertificateEntity> getCertificates() {
+        return certificates;
     }
 }

--- a/src/main/java/com/wultra/app/mobileutilityserver/database/repo/CertificateRepository.java
+++ b/src/main/java/com/wultra/app/mobileutilityserver/database/repo/CertificateRepository.java
@@ -18,7 +18,7 @@
 
 package com.wultra.app.mobileutilityserver.database.repo;
 
-import com.wultra.app.mobileutilityserver.database.model.CertificateFingerprintEntity;
+import com.wultra.app.mobileutilityserver.database.model.CertificateEntity;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.CrudRepository;
 import org.springframework.data.repository.query.Param;
@@ -32,18 +32,18 @@ import java.util.List;
  * @author Petr Dvorak, petr@wultra.com
  */
 @Repository
-public interface CertificateFingerprintRepository extends CrudRepository<CertificateFingerprintEntity, Long> {
+public interface CertificateRepository extends CrudRepository<CertificateEntity, Long> {
 
     /**
-     * Get the collection of SSL pinning fingerprints for a given app.
+     * Get the collection of SSL certificates for a given app.
      * @param appName App name.
-     * @return List of SSL pinning fingerprints.
+     * @return List of SSL certificates.
      */
-    @Query("SELECT s FROM CertificateFingerprintEntity s WHERE s.domain.app.name = :appName")
-    List<CertificateFingerprintEntity> findAllByAppName(@Param("appName") String appName);
+    @Query("SELECT s FROM CertificateEntity s WHERE s.domain.app.name = :appName")
+    List<CertificateEntity> findAllByAppName(@Param("appName") String appName);
 
-    @Query("SELECT s FROM CertificateFingerprintEntity s WHERE s.domain.app.name = :appName AND s.domain.domain = :domain")
-    List<CertificateFingerprintEntity> findFirstByAppNameAndDomain(@Param("appName") String appName, @Param("domain") String domain);
+    @Query("SELECT s FROM CertificateEntity s WHERE s.domain.app.name = :appName AND s.domain.domain = :domain")
+    List<CertificateEntity> findFirstByAppNameAndDomain(@Param("appName") String appName, @Param("domain") String domain);
 
     void deleteAllByExpiresBefore(Long expires);
 

--- a/src/main/java/com/wultra/app/mobileutilityserver/rest/controller/api/AdminController.java
+++ b/src/main/java/com/wultra/app/mobileutilityserver/rest/controller/api/AdminController.java
@@ -20,13 +20,12 @@ package com.wultra.app.mobileutilityserver.rest.controller.api;
 
 import com.wultra.app.mobileutilityserver.rest.errorhandling.AppException;
 import com.wultra.app.mobileutilityserver.rest.errorhandling.AppNotFoundException;
-import com.wultra.app.mobileutilityserver.rest.model.request.CreateApplicationFingerprintDirectRequest;
-import com.wultra.app.mobileutilityserver.rest.model.request.CreateApplicationFingerprintPemRequest;
-import com.wultra.app.mobileutilityserver.rest.model.request.CreateApplicationFingerprintRequest;
+import com.wultra.app.mobileutilityserver.rest.model.request.CreateApplicationCertificatePemRequest;
+import com.wultra.app.mobileutilityserver.rest.model.request.CreateApplicationCertificateRequest;
 import com.wultra.app.mobileutilityserver.rest.model.request.CreateApplicationRequest;
 import com.wultra.app.mobileutilityserver.rest.model.response.ApplicationDetailResponse;
 import com.wultra.app.mobileutilityserver.rest.model.response.ApplicationListResponse;
-import com.wultra.app.mobileutilityserver.rest.model.response.FingerprintDetailResponse;
+import com.wultra.app.mobileutilityserver.rest.model.response.CertificateDetailResponse;
 import com.wultra.app.mobileutilityserver.rest.service.AdminService;
 import io.getlime.core.rest.model.base.response.Response;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -72,24 +71,19 @@ public class AdminController {
         return adminService.applicationDetail(name);
     }
 
-    @PostMapping("apps/{name}/fingerprints/direct")
-    public FingerprintDetailResponse createApplicationFingerprint(@PathVariable("name") String name, @Valid @RequestBody CreateApplicationFingerprintDirectRequest request) throws AppNotFoundException {
-        return adminService.createApplicationFingerprint(name, request);
+    @PostMapping("apps/{name}/certificates/auto")
+    public CertificateDetailResponse createApplicationCertificateAuto(@PathVariable("name") String name, @Valid @RequestBody CreateApplicationCertificateRequest request) throws AppNotFoundException, IOException, CertificateEncodingException, NoSuchAlgorithmException {
+        return adminService.createApplicationCertificate(name, request);
     }
 
-    @PostMapping("apps/{name}/fingerprints/auto")
-    public FingerprintDetailResponse createApplicationFingerprintAuto(@PathVariable("name") String name, @Valid @RequestBody CreateApplicationFingerprintRequest request) throws AppNotFoundException, IOException, CertificateEncodingException, NoSuchAlgorithmException {
-        return adminService.createApplicationFingerprint(name, request);
+    @PostMapping("apps/{name}/certificates/pem")
+    public CertificateDetailResponse createApplicationCertificatePem(@PathVariable("name") String name, @Valid @RequestBody CreateApplicationCertificatePemRequest request) throws AppNotFoundException, IOException, NoSuchAlgorithmException {
+        return adminService.createApplicationCertificate(name, request);
     }
 
-    @PostMapping("apps/{name}/fingerprints/pem")
-    public FingerprintDetailResponse createApplicationFingerprintPem(@PathVariable("name") String name, @Valid @RequestBody CreateApplicationFingerprintPemRequest request) throws AppNotFoundException, IOException, NoSuchAlgorithmException {
-        return adminService.createApplicationFingerprint(name, request);
-    }
-
-    @DeleteMapping("apps/{name}/fingerprints")
-    public Response deleteFingerprint(@PathVariable("name") String appName, @RequestParam("domain") String domain, @RequestParam("fingerprint") String fingerprint) {
-        adminService.deleteFingerprint(appName, domain, fingerprint);
+    @DeleteMapping("apps/{name}/certificates")
+    public Response deleteCertificates(@PathVariable("name") String appName, @RequestParam("domain") String domain, @RequestParam("fingerprint") String fingerprint) {
+        adminService.deleteCertificate(appName, domain, fingerprint);
         return new Response();
     }
 
@@ -99,9 +93,9 @@ public class AdminController {
         return new Response();
     }
 
-    @DeleteMapping("fingerprints/expired")
-    public Response deleteExpiredFingerprints() {
-        adminService.deleteExpiredFingerprints();
+    @DeleteMapping("certificates/expired")
+    public Response deleteExpiredCertificates() {
+        adminService.deleteExpiredCertificates();
         return new Response();
     }
 

--- a/src/main/java/com/wultra/app/mobileutilityserver/rest/controller/api/AppInitializationController.java
+++ b/src/main/java/com/wultra/app/mobileutilityserver/rest/controller/api/AppInitializationController.java
@@ -22,7 +22,7 @@ import com.wultra.app.mobileutilityserver.rest.errorhandling.InvalidChallengeHea
 import com.wultra.app.mobileutilityserver.rest.errorhandling.PublicKeyNotFoundException;
 import com.wultra.app.mobileutilityserver.rest.http.HttpHeaders;
 import com.wultra.app.mobileutilityserver.rest.http.QueryParams;
-import com.wultra.app.mobileutilityserver.rest.model.entity.NamedCertificateFingerprint;
+import com.wultra.app.mobileutilityserver.rest.model.entity.CertificateFingerprint;
 import com.wultra.app.mobileutilityserver.rest.model.response.AppInitResponse;
 import com.wultra.app.mobileutilityserver.rest.model.response.PublicKeyResponse;
 import com.wultra.app.mobileutilityserver.rest.service.CertificateFingerprintService;
@@ -82,7 +82,7 @@ public class AppInitializationController {
         }
 
         // Find the fingerprints
-        final List<NamedCertificateFingerprint> fingerprints = certificateFingerprintService.findCertificateFingerprintsByAppName(appName);
+        final List<CertificateFingerprint> fingerprints = certificateFingerprintService.findCertificateFingerprintsByAppName(appName);
 
         // Return the response
         final AppInitResponse response = new AppInitResponse();

--- a/src/main/java/com/wultra/app/mobileutilityserver/rest/model/converter/CertificateConverter.java
+++ b/src/main/java/com/wultra/app/mobileutilityserver/rest/model/converter/CertificateConverter.java
@@ -17,45 +17,46 @@
  */
 package com.wultra.app.mobileutilityserver.rest.model.converter;
 
-import com.wultra.app.mobileutilityserver.database.model.CertificateFingerprintEntity;
+import com.wultra.app.mobileutilityserver.database.model.CertificateEntity;
 import com.wultra.app.mobileutilityserver.rest.model.entity.CertificateFingerprint;
-import com.wultra.app.mobileutilityserver.rest.model.entity.NamedCertificateFingerprint;
-import com.wultra.app.mobileutilityserver.rest.model.response.FingerprintDetailResponse;
+import com.wultra.app.mobileutilityserver.rest.model.entity.FullCertificateInfo;
+import com.wultra.app.mobileutilityserver.rest.model.response.CertificateDetailResponse;
 import org.springframework.stereotype.Component;
 
 /**
- * Converter class for SSL pinning fingerprint entity conversion.
+ * Converter class for SSL certificate entity conversion.
  *
  * @author Petr Dvorak, petr@wultra.com
  */
 @Component
-public class CertificateFingerprintConverter {
+public class CertificateConverter {
 
     /**
-     * Convert a database representation of a fingerprint to REST API representation.
-     * @param source SSL fingerprint model in DB.
+     * Convert a database representation of a certificate to Admin REST API representation.
+     * @param source SSL certificate model in DB.
+     * @return SSL certificate model in REST API.
+     */
+    public FullCertificateInfo convertFrom(CertificateEntity source) {
+        if (source == null) {
+            return null;
+        }
+        final FullCertificateInfo destination = new FullCertificateInfo();
+        destination.setPem(source.getPem());
+        destination.setFingerprint(source.getFingerprint());
+        destination.setExpires(source.getExpires());
+        return destination;
+    }
+
+    /**
+     * Convert a database representation of a certificate to REST API representation with named fingerprint.
+     * @param source SSL certificate model in DB.
      * @return SSL fingerprint model in REST API.
      */
-    public CertificateFingerprint convertFrom(CertificateFingerprintEntity source) {
+    public CertificateFingerprint convertNamedCertificateFrom(CertificateEntity source) {
         if (source == null) {
             return null;
         }
         final CertificateFingerprint destination = new CertificateFingerprint();
-        destination.setFingerprint(source.getFingerprint());
-        destination.setExpires(source.getExpires());
-        return destination;
-    }
-
-    /**
-     * Convert a database representation of a fingerprint to REST API representation with named fingerprint.
-     * @param source SSL fingerprint model in DB.
-     * @return SSL fingerprint model in REST API.
-     */
-    public NamedCertificateFingerprint convertNamedCertificateFrom(CertificateFingerprintEntity source) {
-        if (source == null) {
-            return null;
-        }
-        final NamedCertificateFingerprint destination = new NamedCertificateFingerprint();
         destination.setName(source.getDomain().getDomain());
         destination.setFingerprint(source.getFingerprint());
         destination.setExpires(source.getExpires());
@@ -63,16 +64,17 @@ public class CertificateFingerprintConverter {
     }
 
     /**
-     * Convert a database representation of a fingerprint to REST API representation used in admin.
-     * @param source SSL fingerprint model in DB.
-     * @return SSL fingerprint model in admin REST API.
+     * Convert a database representation of a certificate to REST API representation used in admin.
+     * @param source SSL certificate model in DB.
+     * @return SSL certificate model in admin REST API.
      */
-    public FingerprintDetailResponse convertFingerprintDetailResponse(CertificateFingerprintEntity source) {
+    public CertificateDetailResponse convertCertificateDetailResponse(CertificateEntity source) {
         if (source == null) {
             return null;
         }
-        final FingerprintDetailResponse destination = new FingerprintDetailResponse();
+        final CertificateDetailResponse destination = new CertificateDetailResponse();
         destination.setName(source.getDomain().getDomain());
+        destination.setPem(source.getPem());
         destination.setFingerprint(source.getFingerprint());
         destination.setExpires(source.getExpires());
         return destination;

--- a/src/main/java/com/wultra/app/mobileutilityserver/rest/model/converter/MobileAppConverter.java
+++ b/src/main/java/com/wultra/app/mobileutilityserver/rest/model/converter/MobileAppConverter.java
@@ -18,11 +18,11 @@
 
 package com.wultra.app.mobileutilityserver.rest.model.converter;
 
-import com.wultra.app.mobileutilityserver.database.model.CertificateFingerprintEntity;
+import com.wultra.app.mobileutilityserver.database.model.CertificateEntity;
 import com.wultra.app.mobileutilityserver.database.model.MobileAppEntity;
 import com.wultra.app.mobileutilityserver.database.model.MobileDomainEntity;
-import com.wultra.app.mobileutilityserver.rest.model.entity.CertificateFingerprint;
 import com.wultra.app.mobileutilityserver.rest.model.entity.Domain;
+import com.wultra.app.mobileutilityserver.rest.model.entity.FullCertificateInfo;
 import com.wultra.app.mobileutilityserver.rest.model.response.ApplicationDetailResponse;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
@@ -35,11 +35,11 @@ import org.springframework.stereotype.Component;
 @Component
 public class MobileAppConverter {
 
-    private final CertificateFingerprintConverter fingerprintConverter;
+    private final CertificateConverter certificateConverter;
 
     @Autowired
-    public MobileAppConverter(CertificateFingerprintConverter fingerprintConverter) {
-        this.fingerprintConverter = fingerprintConverter;
+    public MobileAppConverter(CertificateConverter certificateConverter) {
+        this.certificateConverter = certificateConverter;
     }
 
     /**
@@ -68,9 +68,9 @@ public class MobileAppConverter {
         }
         final Domain destination = new Domain();
         destination.setName(source.getDomain());
-        for (CertificateFingerprintEntity fingerprint : source.getFingerprints()) {
-            final CertificateFingerprint certificateFingerprint = fingerprintConverter.convertFrom(fingerprint);
-            destination.getFingerprints().add(certificateFingerprint);
+        for (CertificateEntity certificateEntity : source.getCertificates()) {
+            final FullCertificateInfo certificateInfo = certificateConverter.convertFrom(certificateEntity);
+            destination.getCertificates().add(certificateInfo);
         }
         return destination;
     }

--- a/src/main/java/com/wultra/app/mobileutilityserver/rest/model/entity/CertificateFingerprint.java
+++ b/src/main/java/com/wultra/app/mobileutilityserver/rest/model/entity/CertificateFingerprint.java
@@ -28,6 +28,7 @@ import lombok.Data;
  */
 @Data
 public class CertificateFingerprint {
+    private String name;
     private String fingerprint;
     private long expires;
     

--- a/src/main/java/com/wultra/app/mobileutilityserver/rest/model/entity/Domain.java
+++ b/src/main/java/com/wultra/app/mobileutilityserver/rest/model/entity/Domain.java
@@ -32,6 +32,6 @@ import java.util.List;
 public class Domain {
 
     private String name;
-    private final List<CertificateFingerprint> fingerprints = new ArrayList<>();
+    private final List<FullCertificateInfo> certificates = new ArrayList<>();
 
 }

--- a/src/main/java/com/wultra/app/mobileutilityserver/rest/model/entity/FullCertificateInfo.java
+++ b/src/main/java/com/wultra/app/mobileutilityserver/rest/model/entity/FullCertificateInfo.java
@@ -16,25 +16,18 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-package com.wultra.app.mobileutilityserver.rest.model.request;
+package com.wultra.app.mobileutilityserver.rest.model.entity;
 
 import lombok.Data;
-import lombok.EqualsAndHashCode;
-
-import javax.validation.constraints.NotBlank;
 
 /**
- * Request for creating fingerprint by directly providing the fingerprint data.
+ * Information about the certificate for the use in Admin section.
  *
  * @author Petr Dvorak, petr@wultra.com
  */
 @Data
-@EqualsAndHashCode(callSuper = true)
-public class CreateApplicationFingerprintDirectRequest extends CreateApplicationFingerprintRequest {
-
-    @NotBlank
+public class FullCertificateInfo {
+    private String pem;
     private String fingerprint;
-    @NotBlank
-    private Long expires;
-
+    private long expires;
 }

--- a/src/main/java/com/wultra/app/mobileutilityserver/rest/model/request/CreateApplicationCertificateDirectRequest.java
+++ b/src/main/java/com/wultra/app/mobileutilityserver/rest/model/request/CreateApplicationCertificateDirectRequest.java
@@ -16,20 +16,24 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-package com.wultra.app.mobileutilityserver.rest.model.response;
+package com.wultra.app.mobileutilityserver.rest.model.request;
 
 import lombok.Data;
+import lombok.EqualsAndHashCode;
+
+import javax.validation.constraints.NotBlank;
 
 /**
- * Response for the fingerprint detail.
+ * Request for creating certificate by directly providing the certificate data.
  *
  * @author Petr Dvorak, petr@wultra.com
  */
 @Data
-public class FingerprintDetailResponse {
-
-    private String name;
+@EqualsAndHashCode(callSuper = true)
+public class CreateApplicationCertificateDirectRequest extends CreateApplicationCertificatePemRequest {
+    @NotBlank
     private String fingerprint;
-    private long expires;
+    @NotBlank
+    private Long expires;
 
 }

--- a/src/main/java/com/wultra/app/mobileutilityserver/rest/model/request/CreateApplicationCertificatePemRequest.java
+++ b/src/main/java/com/wultra/app/mobileutilityserver/rest/model/request/CreateApplicationCertificatePemRequest.java
@@ -24,13 +24,13 @@ import lombok.EqualsAndHashCode;
 import javax.validation.constraints.NotBlank;
 
 /**
- * Request for creating fingerprint by submitting PEM request.
+ * Request for creating certificate by submitting PEM request.
  *
  * @author Petr Dvorak, petr@wultra.com
  */
 @Data
 @EqualsAndHashCode(callSuper = true)
-public class CreateApplicationFingerprintPemRequest extends CreateApplicationFingerprintRequest {
+public class CreateApplicationCertificatePemRequest extends CreateApplicationCertificateRequest {
 
     @NotBlank
     private String pem;

--- a/src/main/java/com/wultra/app/mobileutilityserver/rest/model/request/CreateApplicationCertificateRequest.java
+++ b/src/main/java/com/wultra/app/mobileutilityserver/rest/model/request/CreateApplicationCertificateRequest.java
@@ -16,20 +16,21 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-package com.wultra.app.mobileutilityserver.rest.model.entity;
+package com.wultra.app.mobileutilityserver.rest.model.request;
 
 import lombok.Data;
-import lombok.EqualsAndHashCode;
+
+import javax.validation.constraints.NotBlank;
 
 /**
- * Entity representing full certificate fingerprint including the name.
+ * Request for creating certificate by automatically fetching TLS/SSL certificate of the domain.
  *
  * @author Petr Dvorak, petr@wultra.com
  */
 @Data
-@EqualsAndHashCode(callSuper = true)
-public class NamedCertificateFingerprint extends CertificateFingerprint {
+public class CreateApplicationCertificateRequest {
 
-    private String name;
+    @NotBlank
+    private String domain;
 
 }

--- a/src/main/java/com/wultra/app/mobileutilityserver/rest/model/response/CertificateDetailResponse.java
+++ b/src/main/java/com/wultra/app/mobileutilityserver/rest/model/response/CertificateDetailResponse.java
@@ -16,21 +16,21 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-package com.wultra.app.mobileutilityserver.rest.model.request;
+package com.wultra.app.mobileutilityserver.rest.model.response;
 
 import lombok.Data;
 
-import javax.validation.constraints.NotBlank;
-
 /**
- * Request for creating fingerprint by automatically fetching TLS/SSL certificate of the domain.
+ * Response for the fingerprint detail.
  *
  * @author Petr Dvorak, petr@wultra.com
  */
 @Data
-public class CreateApplicationFingerprintRequest {
+public class CertificateDetailResponse {
 
-    @NotBlank
-    private String domain;
+    private String name;
+    private String pem;
+    private String fingerprint;
+    private long expires;
 
 }

--- a/src/main/java/com/wultra/app/mobileutilityserver/rest/service/CertificateFingerprintService.java
+++ b/src/main/java/com/wultra/app/mobileutilityserver/rest/service/CertificateFingerprintService.java
@@ -18,10 +18,10 @@
 
 package com.wultra.app.mobileutilityserver.rest.service;
 
-import com.wultra.app.mobileutilityserver.database.model.CertificateFingerprintEntity;
-import com.wultra.app.mobileutilityserver.database.repo.CertificateFingerprintRepository;
-import com.wultra.app.mobileutilityserver.rest.model.converter.CertificateFingerprintConverter;
-import com.wultra.app.mobileutilityserver.rest.model.entity.NamedCertificateFingerprint;
+import com.wultra.app.mobileutilityserver.database.model.CertificateEntity;
+import com.wultra.app.mobileutilityserver.database.repo.CertificateRepository;
+import com.wultra.app.mobileutilityserver.rest.model.converter.CertificateConverter;
+import com.wultra.app.mobileutilityserver.rest.model.entity.CertificateFingerprint;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
@@ -37,11 +37,11 @@ import java.util.List;
 @Service
 public class CertificateFingerprintService {
 
-    private final CertificateFingerprintRepository repo;
-    private final CertificateFingerprintConverter converter;
+    private final CertificateRepository repo;
+    private final CertificateConverter converter;
 
     @Autowired
-    public CertificateFingerprintService(CertificateFingerprintRepository repo, CertificateFingerprintConverter converter) {
+    public CertificateFingerprintService(CertificateRepository repo, CertificateConverter converter) {
         this.repo = repo;
         this.converter = converter;
     }
@@ -54,11 +54,11 @@ public class CertificateFingerprintService {
      * @return Collection with SSL pinning fingerprints, possibly empty.
      */
     @Transactional
-    public List<NamedCertificateFingerprint> findCertificateFingerprintsByAppName(String appName) {
-        final List<CertificateFingerprintEntity> fingerprints = repo.findAllByAppName(appName);
-        final List<NamedCertificateFingerprint> result = new ArrayList<>();
-        for (CertificateFingerprintEntity f: fingerprints) {
-            final NamedCertificateFingerprint fingerprint = converter.convertNamedCertificateFrom(f);
+    public List<CertificateFingerprint> findCertificateFingerprintsByAppName(String appName) {
+        final List<CertificateEntity> fingerprints = repo.findAllByAppName(appName);
+        final List<CertificateFingerprint> result = new ArrayList<>();
+        for (CertificateEntity f: fingerprints) {
+            final CertificateFingerprint fingerprint = converter.convertNamedCertificateFrom(f);
             if (fingerprint != null) {
                 result.add(fingerprint);
             }


### PR DESCRIPTION
The change introduces the concept that the database stores certificate info in the PEM format, and one of the pre-calculated attributes we use is the certificate fingerprint. This approach should give us more versatility later since we now technically store all relevant certificate information instead of just storing the hashed value.