### PR TITLE
Fix #46: Improve performance by using cache on frequent queries

### DIFF
--- a/src/main/java/com/wultra/app/mobileutilityserver/config/CacheConfiguration.java
+++ b/src/main/java/com/wultra/app/mobileutilityserver/config/CacheConfiguration.java
@@ -1,0 +1,37 @@
+/*
+ * Wultra Mobile Utility Server
+ * Copyright (C) 2023  Wultra s.r.o.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.wultra.app.mobileutilityserver.config;
+
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Configuration for caching.
+ *
+ * @author Petr Dvorak, petr@wultra.com
+ */
+@Configuration
+@EnableCaching
+public class CacheConfiguration {
+
+    public static final String CERTIFICATE_FINGERPRINTS = "certificateFingerprints";
+    public static final String MOBILE_APPS = "mobileApps";
+    public static final String PRIVATE_KEYS = "privateKeys";
+
+}

--- a/src/main/java/com/wultra/app/mobileutilityserver/rest/filter/ResponseSignFilter.java
+++ b/src/main/java/com/wultra/app/mobileutilityserver/rest/filter/ResponseSignFilter.java
@@ -19,8 +19,8 @@ package com.wultra.app.mobileutilityserver.rest.filter;
 
 import com.wultra.app.mobileutilityserver.rest.http.HttpHeaders;
 import com.wultra.app.mobileutilityserver.rest.http.QueryParams;
-import com.wultra.app.mobileutilityserver.rest.service.MobileAppService;
 import com.wultra.app.mobileutilityserver.rest.service.CryptographicOperationsService;
+import com.wultra.app.mobileutilityserver.rest.service.MobileAppService;
 import io.getlime.security.powerauth.crypto.lib.model.exception.CryptoProviderException;
 import io.getlime.security.powerauth.crypto.lib.model.exception.GenericCryptoException;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -47,6 +47,8 @@ import java.security.spec.InvalidKeySpecException;
 @Component
 public class ResponseSignFilter extends OncePerRequestFilter {
 
+    private static final String PATH_PREFIX = "/app/init";
+
     private final MobileAppService mobileAppService;
 
     private final CryptographicOperationsService cryptographicOperationsService;
@@ -55,6 +57,12 @@ public class ResponseSignFilter extends OncePerRequestFilter {
     public ResponseSignFilter(MobileAppService mobileAppService, CryptographicOperationsService cryptographicOperationsService) {
         this.mobileAppService = mobileAppService;
         this.cryptographicOperationsService = cryptographicOperationsService;
+    }
+
+    @Override
+    protected boolean shouldNotFilter(HttpServletRequest request) {
+        final String url = request.getRequestURI();
+        return !url.startsWith(PATH_PREFIX);
     }
 
     @Override

--- a/src/main/java/com/wultra/app/mobileutilityserver/rest/service/CertificateFingerprintService.java
+++ b/src/main/java/com/wultra/app/mobileutilityserver/rest/service/CertificateFingerprintService.java
@@ -18,11 +18,13 @@
 
 package com.wultra.app.mobileutilityserver.rest.service;
 
+import com.wultra.app.mobileutilityserver.config.CacheConfiguration;
 import com.wultra.app.mobileutilityserver.database.model.CertificateEntity;
 import com.wultra.app.mobileutilityserver.database.repo.CertificateRepository;
 import com.wultra.app.mobileutilityserver.rest.model.converter.CertificateConverter;
 import com.wultra.app.mobileutilityserver.rest.model.entity.CertificateFingerprint;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 
 import javax.transaction.Transactional;
@@ -54,6 +56,7 @@ public class CertificateFingerprintService {
      * @return Collection with SSL pinning fingerprints, possibly empty.
      */
     @Transactional
+    @Cacheable(cacheNames = CacheConfiguration.CERTIFICATE_FINGERPRINTS)
     public List<CertificateFingerprint> findCertificateFingerprintsByAppName(String appName) {
         final List<CertificateEntity> fingerprints = repo.findAllByAppName(appName);
         final List<CertificateFingerprint> result = new ArrayList<>();

--- a/src/main/java/com/wultra/app/mobileutilityserver/rest/service/MobileAppService.java
+++ b/src/main/java/com/wultra/app/mobileutilityserver/rest/service/MobileAppService.java
@@ -17,9 +17,11 @@
  */
 package com.wultra.app.mobileutilityserver.rest.service;
 
+import com.wultra.app.mobileutilityserver.config.CacheConfiguration;
 import com.wultra.app.mobileutilityserver.database.model.MobileAppEntity;
 import com.wultra.app.mobileutilityserver.database.repo.MobileAppRepository;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 
 /**
@@ -42,6 +44,7 @@ public class MobileAppService {
      * @param appName App name.
      * @return True in case the app with given name exists, false otherwise.
      */
+    @Cacheable(cacheNames = CacheConfiguration.MOBILE_APPS)
     public boolean appExists(String appName) {
         return repo.existsByName(appName);
     }
@@ -53,6 +56,7 @@ public class MobileAppService {
      * @return Private key encoded as Base64 representation of the embedded big integer, or null
      * if app with provided name does not exist.
      */
+    @Cacheable(cacheNames = CacheConfiguration.PRIVATE_KEYS)
     public String privateKey(String appName) {
         final MobileAppEntity mobileAppEntity = repo.findFirstByName(appName);
         if (mobileAppEntity == null) {


### PR DESCRIPTION
I tested the difference by running five runs of, ignoring the first two as warmup runs:

```
mvn gatling:test -Dusers=750 -Dduration=20
```

No cache:

![image](https://user-images.githubusercontent.com/516597/225964918-ac348119-6cf9-4a53-a869-86b0db3ffa01.png)

Cache:

![image](https://user-images.githubusercontent.com/516597/225964965-7f9a65b3-e7cc-48cc-9286-76a49f712659.png)
