### PR TITLE
Fix #110: App request timeouts when versions are improperly set

### DIFF
--- a/src/test/java/com/wultra/app/mobileutilityserver/rest/service/AdminServiceTest.java
+++ b/src/test/java/com/wultra/app/mobileutilityserver/rest/service/AdminServiceTest.java
@@ -1,0 +1,81 @@
+/*
+ * Wultra Mobile Utility Server
+ * Copyright (C) 2023  Wultra s.r.o.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package com.wultra.app.mobileutilityserver.rest.service;
+
+import com.wultra.app.mobileutilityserver.rest.model.enums.Platform;
+import com.wultra.app.mobileutilityserver.rest.model.request.CreateApplicationVersionRequest;
+import jakarta.validation.ConstraintViolationException;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.jdbc.Sql;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Test for {@link AdminService}.
+ *
+ * @author Lubos Racansky, lubos.racansky@wultra.com
+ */
+@SpringBootTest
+@ActiveProfiles("test")
+@Transactional
+@Sql
+class AdminServiceTest {
+
+    @Autowired
+    private AdminService tested;
+
+    @Test
+    void testCreateApplicationVersion_successful() {
+        final CreateApplicationVersionRequest request = new CreateApplicationVersionRequest();
+        request.setPlatform(Platform.ANDROID);
+        request.setSuggestedVersion("1.2.3");
+
+        final var result = tested.createApplicationVersion("test-app", request);
+
+        assertNotNull(result.getId());
+    }
+
+    @Test
+    void testCreateApplicationVersion_alreadyExists() {
+        final CreateApplicationVersionRequest request = new CreateApplicationVersionRequest();
+        request.setPlatform(Platform.IOS);
+        request.setSuggestedVersion("1.2.3");
+        request.setMajorOsVersion(11);
+
+        final var result = assertThrows(ConstraintViolationException.class, () -> tested.createApplicationVersion("test-app", request));
+
+        assertEquals("Application version already exists, applicationName=test-app, platform=IOS, majorOsVersion=11", result.getMessage());
+    }
+
+    @Test
+    void testCreateApplicationVersion_alreadyExists_majorVersionNull() {
+        final CreateApplicationVersionRequest request = new CreateApplicationVersionRequest();
+        request.setPlatform(Platform.IOS);
+        request.setSuggestedVersion("1.2.3");
+        request.setMajorOsVersion(null);
+
+        final var result = assertThrows(ConstraintViolationException.class, () -> tested.createApplicationVersion("test-app", request));
+
+        assertEquals("Application version already exists, applicationName=test-app, platform=IOS, majorOsVersion=null", result.getMessage());
+    }
+
+}

--- a/src/test/java/com/wultra/app/mobileutilityserver/rest/service/MobileAppServiceTest.java
+++ b/src/test/java/com/wultra/app/mobileutilityserver/rest/service/MobileAppServiceTest.java
@@ -166,4 +166,19 @@ class MobileAppServiceTest {
         assertEquals(VerifyVersionResult.Update.NOT_REQUIRED, result.getUpdate(), "Newer version is suggested, but for major version 29 the threshold is lowered.");
         assertNull(result.getMessage());
     }
+
+    @Test
+    void testVerifyVersion_duplicateEntries() {
+        final VerifyVersionRequest request = VerifyVersionRequest.builder()
+                .applicationVersion("3.2.1")
+                .applicationName("duplicate-entries")
+                .platform(VerifyVersionRequest.Platform.IOS)
+                .systemVersion("11.2.4")
+                .build();
+
+        final VerifyVersionResult result = tested.verifyVersion(request);
+
+        assertEquals(VerifyVersionResult.Update.NOT_REQUIRED, result.getUpdate(), "Misconfiguration should not throw an exception.");
+        assertNull(result.getMessage());
+    }
 }

--- a/src/test/resources/com/wultra/app/mobileutilityserver/rest/service/AdminServiceTest.sql
+++ b/src/test/resources/com/wultra/app/mobileutilityserver/rest/service/AdminServiceTest.sql
@@ -1,0 +1,6 @@
+insert into ssl_mobile_app(id, name)
+values (1, 'test-app');
+
+insert into ssl_mobile_app_version(id, app_id, platform, suggested_version, required_version, major_os_version, message_key)
+values (nextval('ssl_mobile_app_version_seq'), 1, 'IOS', '3.3.0', null, null, 'suggested-app.performance'),
+       (nextval('ssl_mobile_app_version_seq'), 1, 'IOS', '3.1.0', null, 11, null);

--- a/src/test/resources/com/wultra/app/mobileutilityserver/rest/service/MobileAppServiceTest.sql
+++ b/src/test/resources/com/wultra/app/mobileutilityserver/rest/service/MobileAppServiceTest.sql
@@ -1,7 +1,8 @@
 insert into ssl_mobile_app(id, name)
 values (1, 'suggested-app'),
        (2, 'required-app'),
-       (3, 'suggested-and-required-app');
+       (3, 'suggested-and-required-app'),
+       (4, 'duplicate-entries');
 
 insert into ssl_mobile_app_version(id, app_id, platform, suggested_version, required_version, major_os_version, message_key)
 values (nextval('ssl_mobile_app_version_seq'), 1, 'IOS', '3.3.0', null, null, 'suggested-app.performance'),
@@ -12,7 +13,9 @@ values (nextval('ssl_mobile_app_version_seq'), 1, 'IOS', '3.3.0', null, null, 's
        (nextval('ssl_mobile_app_version_seq'), 2, 'ANDROID', null, '3.3.0', null, null),
        (nextval('ssl_mobile_app_version_seq'), 2, 'IOS', null, '3.2.0', 11, null),
        (nextval('ssl_mobile_app_version_seq'), 2, 'ANDROID', null, '2.9.0', 29, null),
-       (nextval('ssl_mobile_app_version_seq'), 3, 'IOS', '3.0.0', '2.0.0', null, null);
+       (nextval('ssl_mobile_app_version_seq'), 3, 'IOS', '3.0.0', '2.0.0', null, null),
+       (nextval('ssl_mobile_app_version_seq'), 4, 'IOS', '1.1.0', null, null, null),
+       (nextval('ssl_mobile_app_version_seq'), 4, 'IOS', null, '3.1.2', null, null);
 
 insert into ssl_localized_text(message_key, text, language)
 values ('required-app.internet-banking', 'Upgrade is required to make internet banking working.', 'en'),


### PR DESCRIPTION
- Validate version duplicity for create at Admin API
- Add fail-safe routine for /init endpoint