### PR TITLE
Rename appname to mobile-utility-server in logback configuration

### DIFF
--- a/deploy/conf/logback/mus-logback.xml
+++ b/deploy/conf/logback/mus-logback.xml
@@ -3,7 +3,7 @@
     <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
         <encoder class="net.logstash.logback.encoder.LogstashEncoder">
             <includeMdc>true</includeMdc>
-            <customFields>{"appname":"mobile_utility_server"}</customFields>
+            <customFields>{"appname":"mobile-utility-server"}</customFields>
         </encoder>
     </appender>
 


### PR DESCRIPTION
A follow-up to #119