### PR TITLE
Fix #474: Change mus_certificate.expires type from integer to bigint

### DIFF
--- a/docs/Database-Structure.md
+++ b/docs/Database-Structure.md
@@ -69,7 +69,7 @@ Table with TLS/SSL certificate and fingerprints that should be pinned in the mob
 | `id`               | `INTEGER`      | Primary key for the table, automatically incremented value.               |
 | `pem`              | `TEXT`         | Original certificate value in PEM format.                                 |
 | `fingerprint`      | `VARCHAR(255)` | Value of the certificate fingerprint.                                     |
-| `expires`          | `INTEGER`      | Unix timestamp (seconds since Jan 1, 1970) of the certificate expiration. |
+| `expires`          | `BIGINT`       | Unix timestamp (seconds since Jan 1, 1970) of the certificate expiration. |
 | `mobile_domain_id` | `INTEGER`      | Reference to related application domain in the `mus_mobile_domain` table. |
 
 #### Sequence

--- a/docs/Migration-Instructions.md
+++ b/docs/Migration-Instructions.md
@@ -2,6 +2,7 @@
 
 This page contains Mobile Utility Server migration instructions.
 
+- [Mobile Utility Server 2.1.0](./Mobile-Utility-Server-2.1.0.md)
 - [Mobile Utility Server 2.0.0](./Mobile-Utility-Server-2.0.0.md)
 - [Mobile Utility Server 1.5.0](./Mobile-Utility-Server-1.5.0.md)
 - [Mobile Utility Server 1.4.0](./Mobile-Utility-Server-1.4.0.md)

--- a/docs/Mobile-Utility-Server-2.1.0.md
+++ b/docs/Mobile-Utility-Server-2.1.0.md
@@ -1,0 +1,15 @@
+# Migration from 2.0.x to 2.1.0
+
+This guide provides instructions for migrating from PowerAuth Mobile Utility Server version `2.0.x` to version `2.1.0`.
+
+## Database Changes
+
+For convenience, you can use liquibase for your database migration.
+
+For manual changes, use SQL scripts:
+- [PostgreSQL script](sql/postgresql/2.1.0-migration.sql)
+- [Oracle script](sql/oracle/2.1.0-migration.sql)
+
+### Table mus_certificate
+
+The type of the `expires` column has been changed from `integer` to `bigint` (Postgres) / `NUMBER(38,0)` (Oracle).

--- a/docs/db/changelog/changesets/mobile-utility-server/2.1.x/20260325-change-certificate-expires-to-bigint.xml
+++ b/docs/db/changelog/changesets/mobile-utility-server/2.1.x/20260325-change-certificate-expires-to-bigint.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  ~ Wultra Mobile Utility Server
+  ~ Copyright (C) 2026  Wultra s.r.o.
+  ~
+  ~ This program is free software: you can redistribute it and/or modify
+  ~ it under the terms of the GNU Affero General Public License as
+  ~ published by the Free Software Foundation, either version 3 of the
+  ~ License, or (at your option) any later version.
+  ~
+  ~ This program is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  ~ GNU Affero General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Affero General Public License
+  ~ along with this program.  If not, see <https://www.gnu.org/licenses/>.
+  -->
+
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+         http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.20.xsd">
+
+    <changeSet id="1" author="Pavel Sindelar" logicalFilePath="mobile-utility-server/2.1.x/20260325-change-certificate-expires-to-bigint.xml">
+        <comment>Change expires column type from integer to bigint to support certificates expiring after 2038-01-19.</comment>
+        <modifyDataType tableName="mus_certificate" columnName="expires" newDataType="bigint"/>
+    </changeSet>
+
+    <changeSet id="2" author="Pavel Sindelar" logicalFilePath="mobile-utility-server/2.1.x/20260325-change-certificate-expires-to-bigint.xml" dbms="mssql">
+        <comment>Re-apply NOT NULL on expires after type change in MSSQL (it drops constraint on ALTER COLUMN).</comment>
+        <addNotNullConstraint tableName="mus_certificate" columnName="expires" columnDataType="bigint"/>
+    </changeSet>
+
+</databaseChangeLog>

--- a/docs/db/changelog/changesets/mobile-utility-server/2.1.x/db.changelog-version.xml
+++ b/docs/db/changelog/changesets/mobile-utility-server/2.1.x/db.changelog-version.xml
@@ -2,7 +2,7 @@
 
 <!--
   ~ Wultra Mobile Utility Server
-  ~ Copyright (C) 2023  Wultra s.r.o.
+  ~ Copyright (C) 2026  Wultra s.r.o.
   ~
   ~ This program is free software: you can redistribute it and/or modify
   ~ it under the terms of the GNU Affero General Public License as
@@ -20,12 +20,9 @@
 
 <databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
                    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
-				   					   http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.10.xsd">
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.10.xsd">
 
-    <!-- mobile-utility-server -->
-    <include file="1.5.x/db.changelog-version.xml" relativeToChangelogFile="true" />
-    <include file="2.0.x/db.changelog-version.xml" relativeToChangelogFile="true" />
-    <include file="2.1.x/db.changelog-version.xml" relativeToChangelogFile="true" />
+    <!-- 2.1.x -->
+    <include file="20260325-change-certificate-expires-to-bigint.xml" relativeToChangelogFile="true"/>
 
 </databaseChangeLog>

--- a/docs/sql/oracle/2.1.0-migration.sql
+++ b/docs/sql/oracle/2.1.0-migration.sql
@@ -1,0 +1,3 @@
+-- Changeset mobile-utility-server/2.1.x/20260325-change-certificate-expires-to-bigint.xml::1::Pavel Sindelar
+-- Change expires column type from integer to bigint to support certificates expiring after 2038-01-19.
+ALTER TABLE mus_certificate MODIFY expires NUMBER(38, 0);

--- a/docs/sql/oracle/create_schema.sql
+++ b/docs/sql/oracle/create_schema.sql
@@ -95,3 +95,7 @@ ALTER TABLE mus_certificate ADD depth INTEGER DEFAULT 0 NOT NULL;
 -- Add ssl_pinning_required column to mus_mobile_domain table
 ALTER TABLE mus_mobile_domain ADD ssl_pinning_required BOOLEAN DEFAULT 1 NOT NULL;
 
+-- Changeset mobile-utility-server/2.1.x/20260325-change-certificate-expires-to-bigint.xml::1::Pavel Sindelar
+-- Change expires column type from integer to bigint to support certificates expiring after 2038-01-19.
+ALTER TABLE mus_certificate MODIFY expires NUMBER(38, 0);
+

--- a/docs/sql/postgresql/2.1.0-migration.sql
+++ b/docs/sql/postgresql/2.1.0-migration.sql
@@ -1,0 +1,3 @@
+-- Changeset mobile-utility-server/2.1.x/20260325-change-certificate-expires-to-bigint.xml::1::Pavel Sindelar
+-- Change expires column type from integer to bigint to support certificates expiring after 2038-01-19.
+ALTER TABLE mus_certificate ALTER COLUMN expires TYPE BIGINT USING (expires::BIGINT);

--- a/docs/sql/postgresql/create_schema.sql
+++ b/docs/sql/postgresql/create_schema.sql
@@ -95,3 +95,7 @@ ALTER TABLE mus_certificate ADD depth INTEGER DEFAULT 0 NOT NULL;
 -- Add ssl_pinning_required column to mus_mobile_domain table
 ALTER TABLE mus_mobile_domain ADD ssl_pinning_required BOOLEAN DEFAULT TRUE NOT NULL;
 
+-- Changeset mobile-utility-server/2.1.x/20260325-change-certificate-expires-to-bigint.xml::1::Pavel Sindelar
+-- Change expires column type from integer to bigint to support certificates expiring after 2038-01-19.
+ALTER TABLE mus_certificate ALTER COLUMN expires TYPE BIGINT USING (expires::BIGINT);
+

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
 
     <groupId>com.wultra.app</groupId>
     <artifactId>mobile-utility-server</artifactId>
-    <version>2.0.0</version>
+    <version>2.1.0-SNAPSHOT</version>
     <packaging>war</packaging>
     <name>Mobile Utility Server</name>
     <description>Utility server with various features suitable for mobile apps</description>


### PR DESCRIPTION
Change `mus_certificate.expires` column type to `bigint` to prevent overflow.