### PR TITLE
Fix #479: JSON Logging Foundation

### DIFF
--- a/docker/conf/logback/mus-logback.xml
+++ b/docker/conf/logback/mus-logback.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <configuration>
-    <springProperty scope="context" name="appname" source="spring.application.name"/>
+    <springProperty scope="context" name="appname" source="spring.application.name" defaultValue="unknown"/>
     <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
         <encoder class="net.logstash.logback.encoder.LogstashEncoder">
             <includeMdc>true</includeMdc>

--- a/docker/conf/logback/mus-logback.xml
+++ b/docker/conf/logback/mus-logback.xml
@@ -1,9 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <configuration>
+    <springProperty scope="context" name="appname" source="spring.application.name"/>
     <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
         <encoder class="net.logstash.logback.encoder.LogstashEncoder">
             <includeMdc>true</includeMdc>
-            <customFields>{"appname":"mobile-utility-server"}</customFields>
+            <omitEmptyFields>true</omitEmptyFields>
+            <customFields>{"appname":"${appname}"}</customFields>
         </encoder>
     </appender>
 


### PR DESCRIPTION
## Summary

Fixes #479 — JSON Logging Foundation for `mobile-utility-server`.

### Changes

- **L3**: Replace hardcoded `appname` in `customFields` with `<springProperty>` sourced from `spring.application.name`
- **+**: Add `<omitEmptyFields>true</omitEmptyFields>` to suppress empty MDC fields from JSON output

### Affected files

- `docker/conf/logback/mus-logback.xml`

### Notes

- `spring.application.name=mobile-utility-server` already set ✅
- `logstash-logback-encoder` version `8.1` is already the latest — no version bump needed ✅

### References

- Issue: #479
- Epic: wultra/tasklist#863 (JSON Logging Foundation)
- Logging Guideline: https://github.com/wultra/development-internal/wiki/Logging-Guideline

---

### Follow-up: defaultValue for springProperty

Added `defaultValue="unknown"` to `<springProperty>` in all logback configs.

`<springProperty>` is fully supported when the config is loaded via Spring Boot's Logback configurator (standard production path via `logging.config`). The `defaultValue` is a safety net for the edge case where the file is loaded as a plain Logback config outside of Spring Boot — in that scenario `spring.application.name` cannot be resolved and the fallback prevents `appname_IS_UNDEFINED` appearing in log output.