### PR TITLE
fix #497: register lombok annotation processor

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -260,6 +260,18 @@
                 </configuration>
             </plugin>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>org.projectlombok</groupId>
+                            <artifactId>lombok</artifactId>
+                        </path>
+                    </annotationProcessorPaths>
+                </configuration>
+            </plugin>
+            <plugin>
                 <groupId>io.gatling</groupId>
                 <artifactId>gatling-maven-plugin</artifactId>
                 <version>4.21.5</version>


### PR DESCRIPTION
## Description

Registered Lombok as an explicit annotation processor in the Maven compiler plugin configuration.

The project already depends on Lombok, but the compiler plugin did not explicitly list Lombok under annotation processor paths. This change adds the processor configuration to the root `pom.xml` while preserving the existing Spring Boot, Gatling, enforcer, CycloneDX, and publishing plugin setup.

## Motivation and Context

Starting with JDK 23, annotation processor discovery is disabled by default. As a result, projects that rely on implicit Lombok discovery can fail to compile on Java 25 because Lombok-generated members are not available to `javac`.

This repository is tracked under the Java 25 / Lombok compatibility epic. Explicitly registering Lombok keeps local Java 25 compilation working and aligns the build with the approach used in the related repositories.

## Testing

The project compiles successfully with tests skipped:

```bash
mvn -DskipTests compile
```

Closes #497
