### PR TITLE
Fix #496: Structured Log Quality

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -62,7 +62,7 @@
 
         <!-- Wultra dependencies -->
         <powerauth-crypto.version>2.0.1</powerauth-crypto.version>
-        <wultra-core.version>2.1.0</wultra-core.version>
+        <wultra-core.version>2.2.0-SNAPSHOT</wultra-core.version>
 
         <!-- Dependency Versions -->
         <bc.version>1.83</bc.version>
@@ -169,6 +169,11 @@
             <groupId>net.logstash.logback</groupId>
             <artifactId>logstash-logback-encoder</artifactId>
             <version>${logstash.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.wultra.core</groupId>
+            <artifactId>logging-support</artifactId>
+            <version>${wultra-core.version}</version>
         </dependency>
 
         <!-- Monitoring -->

--- a/src/main/java/com/wultra/app/mobileutilityserver/rest/controller/api/AppInitializationController.java
+++ b/src/main/java/com/wultra/app/mobileutilityserver/rest/controller/api/AppInitializationController.java
@@ -46,6 +46,8 @@ import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
+import static net.logstash.logback.argument.StructuredArguments.kv;
+
 /**
  * Controller with generic information needed for app initialization.
  *
@@ -135,7 +137,7 @@ public class AppInitializationController {
 
             return new AppInitResponse(fingerprints, verifyVersionResult, domainsConfig);
         } else {
-            logger.debug("Context for verifying version not provided for application name: {}", applicationName);
+            logger.debug("Context for verifying version not provided", kv("applicationName", applicationName));
             return new AppInitResponse(fingerprints, null, domainsConfig);
         }
     }

--- a/src/main/java/com/wultra/app/mobileutilityserver/rest/errorhandling/ExceptionHandlingControllerAdvice.java
+++ b/src/main/java/com/wultra/app/mobileutilityserver/rest/errorhandling/ExceptionHandlingControllerAdvice.java
@@ -40,6 +40,8 @@ import jakarta.validation.ConstraintViolation;
 import jakarta.validation.ConstraintViolationException;
 import lombok.extern.slf4j.Slf4j;
 
+import static net.logstash.logback.argument.StructuredArguments.kv;
+
 /**
  * Controller advice responsible for error handling.
  *
@@ -54,8 +56,7 @@ public class ExceptionHandlingControllerAdvice {
     public @ResponseBody ErrorResponse handleMissingRequestHeaderException(ServletRequestBindingException ex) {
         final String code = "UNKNOWN_ERROR";
         final String message = "An error occurred when processing the request.";
-        logger.error("Unknown error happened: {}", ex.getMessage());
-        logger.debug("Exception detail: ", ex);
+        logger.error("Unknown error happened", ex);
         return new ErrorResponse(code, message);
     }
 
@@ -64,8 +65,7 @@ public class ExceptionHandlingControllerAdvice {
     public @ResponseBody ErrorResponse handlePublicKeyNotFoundException(PublicKeyNotFoundException ex) {
         final String code = "PUBLIC_KEY_NOT_FOUND";
         final String message = "Public key for the provided app name was not found.";
-        logger.warn("Public key for the provided app name: {} was not found: {}", ex.getAppName(), ex.getMessage());
-        logger.debug("Exception detail: ", ex);
+        logger.warn("Public key for provided app name was not found", kv("appName", ex.getAppName()), ex);
         return new ErrorResponse(code, message);
     }
 
@@ -74,8 +74,7 @@ public class ExceptionHandlingControllerAdvice {
     public @ResponseBody ErrorResponse handleAppException(AppException ex) {
         final String code = "APP_EXCEPTION";
         final String message = ex.getMessage();
-        logger.warn("Problem occurred while working with applications: {}", ex.getMessage());
-        logger.debug("Exception detail: ", ex);
+        logger.warn("Problem occurred while working with applications", ex);
         return new ErrorResponse(code, message);
     }
 
@@ -84,8 +83,7 @@ public class ExceptionHandlingControllerAdvice {
     public @ResponseBody ErrorResponse handleAppNotFoundException(AppNotFoundException ex) {
         final String code = "APP_NOT_FOUND";
         final String message = "App with a provided ID was not found.";
-        logger.warn("Application for a provided app name: {} was not found: {}", ex.getAppName(), ex.getMessage());
-        logger.debug("Exception detail: ", ex);
+        logger.warn("Application for provided app name was not found", kv("appName", ex.getAppName()), ex);
         return new ErrorResponse(code, message);
     }
 
@@ -94,8 +92,7 @@ public class ExceptionHandlingControllerAdvice {
     public @ResponseBody ErrorResponse handleInvalidChallengeHeaderException(InvalidChallengeHeaderException ex) {
         final String code = "INVALID_CHALLENGE";
         final String message = "Request does not contain correct challenge header, a random Base64 encoded challenge with 16B - 32B raw length is required.";
-        logger.error("Request does not contain correct challenge header, a random Base64 encoded challenge with 16B - 32B raw length is required: {}", ex.getMessage());
-        logger.debug("Exception detail: ", ex);
+        logger.error("Request does not contain correct challenge header", ex);
         return new ErrorResponse(code, message);
     }
 
@@ -110,8 +107,7 @@ public class ExceptionHandlingControllerAdvice {
     @ExceptionHandler(MethodArgumentNotValidException.class)
     @ResponseStatus(HttpStatus.BAD_REQUEST)
     public @ResponseBody com.wultra.core.rest.model.base.response.ErrorResponse handleMethodArgumentNotValidException(MethodArgumentNotValidException e) {
-        logger.warn("Error occurred when calling an API: {}", e.getMessage());
-        logger.debug("Exception detail: ", e);
+        logger.warn("Error occurred when calling an API", e);
         final ExtendedError error = new ExtendedError("ERROR_REQUEST", "Invalid method parameter value");
         for (FieldError fieldError : e.getBindingResult().getFieldErrors()) {
             error.getViolations().add(
@@ -130,8 +126,7 @@ public class ExceptionHandlingControllerAdvice {
     @ExceptionHandler(ConstraintViolationException.class)
     @ResponseStatus(HttpStatus.BAD_REQUEST)
     public @ResponseBody com.wultra.core.rest.model.base.response.ErrorResponse handleConstraintViolationException(ConstraintViolationException e) {
-        logger.warn("Error occurred when calling an API: {}", e.getMessage());
-        logger.debug("Exception detail: ", e);
+        logger.warn("Error occurred when calling an API", e);
         final ExtendedError error = new ExtendedError("ERROR_REQUEST", e.getMessage());
         for (ConstraintViolation<?> violation : e.getConstraintViolations()) {
             error.getViolations().add(
@@ -150,8 +145,7 @@ public class ExceptionHandlingControllerAdvice {
     @ExceptionHandler(MissingServletRequestParameterException.class)
     @ResponseStatus(HttpStatus.BAD_REQUEST)
     public @ResponseBody com.wultra.core.rest.model.base.response.ErrorResponse handleMissingServletRequestParameterException(MissingServletRequestParameterException e) {
-        logger.warn("Error occurred when calling an API: {}", e.getMessage());
-        logger.debug("Exception detail: ", e);
+        logger.warn("Error occurred when calling an API", e);
         return new com.wultra.core.rest.model.base.response.ErrorResponse("ERROR_REQUEST", e.getMessage());
     }
 
@@ -164,8 +158,7 @@ public class ExceptionHandlingControllerAdvice {
     @ExceptionHandler(HttpMediaTypeException.class)
     @ResponseStatus(HttpStatus.BAD_REQUEST)
     public @ResponseBody com.wultra.core.rest.model.base.response.ErrorResponse handleHttpMediaTypeException(HttpMediaTypeException e) {
-        logger.warn("Error occurred when calling an API: {}", e.getMessage());
-        logger.debug("Exception detail: ", e);
+        logger.warn("Error occurred when calling an API", e);
         return new com.wultra.core.rest.model.base.response.ErrorResponse("ERROR_REQUEST", e.getMessage());
     }
 
@@ -178,8 +171,7 @@ public class ExceptionHandlingControllerAdvice {
     @ExceptionHandler(RequestRejectedException.class)
     @ResponseStatus(HttpStatus.BAD_REQUEST)
     public @ResponseBody com.wultra.core.rest.model.base.response.ErrorResponse handleRequestRejectedException(RequestRejectedException e) {
-        logger.warn("Error occurred when calling an API: {}", e.getMessage());
-        logger.debug("Exception detail: ", e);
+        logger.warn("Error occurred when calling an API", e);
         return new com.wultra.core.rest.model.base.response.ErrorResponse("ERROR_REQUEST", e.getMessage());
     }
 
@@ -192,8 +184,7 @@ public class ExceptionHandlingControllerAdvice {
     @ExceptionHandler(HttpRequestMethodNotSupportedException.class)
     @ResponseStatus(HttpStatus.BAD_REQUEST)
     public @ResponseBody com.wultra.core.rest.model.base.response.ErrorResponse handleHttpRequestMethodNotSupportedException(HttpRequestMethodNotSupportedException e) {
-        logger.warn("Error occurred when calling an API: {}", e.getMessage());
-        logger.debug("Exception detail: ", e);
+        logger.warn("Error occurred when calling an API", e);
         return new com.wultra.core.rest.model.base.response.ErrorResponse("ERROR_REQUEST", e.getMessage());
     }
 
@@ -206,8 +197,7 @@ public class ExceptionHandlingControllerAdvice {
     @ExceptionHandler(HttpMessageConversionException.class)
     @ResponseStatus(HttpStatus.BAD_REQUEST)
     public @ResponseBody com.wultra.core.rest.model.base.response.ErrorResponse handleHttpMessageConversionException(HttpMessageConversionException e) {
-        logger.warn("Error occurred when calling an API: {}", e.getMessage());
-        logger.debug("Exception detail: ", e);
+        logger.warn("Error occurred when calling an API", e);
         return new com.wultra.core.rest.model.base.response.ErrorResponse("ERROR_REQUEST", "Unable to map request data. Check the JSON payload.");
     }
 
@@ -220,8 +210,7 @@ public class ExceptionHandlingControllerAdvice {
     @ExceptionHandler(AccessDeniedException.class)
     @ResponseStatus(HttpStatus.UNAUTHORIZED)
     public @ResponseBody com.wultra.core.rest.model.base.response.ErrorResponse handleAccessDeniedException(AccessDeniedException e) {
-        logger.warn("Error occurred when calling an API: {}", e.getMessage());
-        logger.debug("Exception detail: ", e);
+        logger.warn("Error occurred when calling an API", e);
         return new com.wultra.core.rest.model.base.response.ErrorResponse("ERROR_AUTHENTICATION", e.getMessage());
     }
 
@@ -234,8 +223,7 @@ public class ExceptionHandlingControllerAdvice {
     @ExceptionHandler(NoResourceFoundException.class)
     @ResponseStatus(HttpStatus.NOT_FOUND)
     public @ResponseBody ErrorResponse handleNoResourceFoundException(final NoResourceFoundException e) {
-        logger.warn("Error occurred when calling an API: {}", e.getMessage());
-        logger.debug("Exception detail: ", e);
+        logger.warn("Error occurred when calling an API", e);
         return new ErrorResponse("ERROR_NOT_FOUND", "Resource not found.");
     }
 
@@ -248,8 +236,7 @@ public class ExceptionHandlingControllerAdvice {
     @ExceptionHandler(DomainNameCertificateMismatchException.class)
     @ResponseStatus(HttpStatus.BAD_REQUEST)
     public @ResponseBody ErrorResponse handleDomainNameCertificateMismatchException(final DomainNameCertificateMismatchException e) {
-        logger.warn("Provided certificate does not match the domain name: {}", e.getDomainName());
-        logger.debug("Exception detail: ", e);
+        logger.warn("Provided certificate does not match the domain name", kv("domainName", e.getDomainName()), e);
         return new ErrorResponse("ERROR_REQUEST", e.getMessage());
     }
 }

--- a/src/main/java/com/wultra/app/mobileutilityserver/rest/filter/ResponseSignFilter.java
+++ b/src/main/java/com/wultra/app/mobileutilityserver/rest/filter/ResponseSignFilter.java
@@ -40,6 +40,8 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.extern.slf4j.Slf4j;
 
+import static net.logstash.logback.argument.StructuredArguments.kv;
+
 /**
  * Filter that signs the response data with a signature that depends on the received challenge.
  *
@@ -86,7 +88,7 @@ public class ResponseSignFilter extends OncePerRequestFilter {
                     // Set the request header
                     response.setHeader(HttpHeaders.RESPONSE_SIGNATURE, ecdsaSignature);
                 } catch (InvalidKeySpecException | CryptoProviderException | InvalidKeyException | GenericCryptoException ex) {
-                    logger.error("Unable to sign response, appName: {}", appName, ex);
+                    logger.error("Unable to sign response", kv("appName", appName), ex);
                     throw new IOException("Unable to sign response, appName: " + appName, ex);
                 }
             }

--- a/src/main/java/com/wultra/app/mobileutilityserver/rest/http/HttpHeaders.java
+++ b/src/main/java/com/wultra/app/mobileutilityserver/rest/http/HttpHeaders.java
@@ -23,6 +23,8 @@ import org.apache.commons.lang3.StringUtils;
 
 import lombok.extern.slf4j.Slf4j;
 
+import static net.logstash.logback.argument.StructuredArguments.kv;
+
 /**
  * Class with constants for HTTP request / response headers.
  *
@@ -44,7 +46,7 @@ public class HttpHeaders {
     public static boolean validChallengeHeader(String challengeHeader) {
         try {
             if (StringUtils.isEmpty(challengeHeader)) {
-                logger.warn("Missing or blank challenge header: {}", challengeHeader);
+                logger.warn("Missing or blank challenge header", kv("challengeHeader", challengeHeader));
                 return false;
             }
             final byte[] challengeBytes = Base64.getDecoder().decode(challengeHeader);
@@ -56,8 +58,7 @@ public class HttpHeaders {
                 return false;
             }
         } catch (IllegalArgumentException ex) {
-            logger.warn("Invalid Base64 value received in the header: {}", challengeHeader);
-            logger.debug("Exception detail: {}", ex.getMessage(), ex);
+            logger.warn("Invalid Base64 value received in the challenge header", kv("challengeHeader", challengeHeader), ex);
             return false;
         }
     }

--- a/src/main/java/com/wultra/app/mobileutilityserver/rest/service/AdminService.java
+++ b/src/main/java/com/wultra/app/mobileutilityserver/rest/service/AdminService.java
@@ -40,6 +40,8 @@ import org.bouncycastle.openssl.PEMParser;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import static net.logstash.logback.argument.StructuredArguments.kv;
+
 import com.wultra.app.mobileutilityserver.database.model.CertificateEntity;
 import com.wultra.app.mobileutilityserver.database.model.LocalizedTextEntity;
 import com.wultra.app.mobileutilityserver.database.model.MobileAppEntity;
@@ -162,7 +164,7 @@ public class AdminService {
             for (CertificateEntity cert : certificateEntityOptional) {
                 if (fingerprint.equalsIgnoreCase(cert.getFingerprint())) {
                     final CertificateDetailResponse response = certificateConverter.convertCertificateDetailResponse(cert);
-                    logger.info("Certificate up-to-date: {}", response);
+                    logger.info("", kv("action", "addOrRefreshCertificate"), kv("state", "noChange"), kv("appName", appName), kv("domain", domain));
                     return response;
                 }
             }
@@ -187,7 +189,7 @@ public class AdminService {
         final CertificateEntity savedCertificateEntity = certificateRepository.save(certificateEntity);
 
         final CertificateDetailResponse response = certificateConverter.convertCertificateDetailResponse(savedCertificateEntity);
-        logger.info("Certificate refreshed: {}", response);
+        logger.info("", kv("action", "addOrRefreshCertificate"), kv("state", "succeeded"), kv("appName", appName), kv("domain", domain));
         return response;
     }
 
@@ -228,7 +230,7 @@ public class AdminService {
 
         final X509Certificate cert = fetchCertificate(domain);
         final String certPem = cryptographicOperationsService.certificateToPem(cert);
-        logger.info("Certificate read for app: {}, domain: {}\n{}", appName, domain, certPem);
+        logger.info("", kv("action", "createCertificate"), kv("state", "initiated"), kv("appName", appName), kv("domain", domain));
 
         final CreateApplicationCertificatePemRequest innerRequest = new CreateApplicationCertificatePemRequest();
         innerRequest.setDomain(domain);
@@ -273,19 +275,19 @@ public class AdminService {
 
     @Transactional(readOnly = true)
     public ApplicationVersionListResponse applicationVersionList(final String applicationName) {
-        logger.debug("Looking for application versions name: {}", applicationName);
+        logger.debug("Looking for application versions", kv("applicationName", applicationName));
         return convertVersions(mobileAppVersionRepository.findByApplicationName(applicationName));
     }
 
     @Transactional(readOnly = true)
     public ApplicationVersionDetailResponse applicationVersionDetail(final String applicationName, final Long id) {
-        logger.debug("Looking for application version name: {}, ID: {}", applicationName, id);
+        logger.debug("Looking for application version", kv("applicationName", applicationName), kv("id", id));
         return convert(mobileAppVersionRepository.findById(id)
                 .orElseThrow(() -> new ConstraintViolationException("Version not found, ID: " + id, Collections.emptySet())));
     }
 
     public ApplicationVersionDetailResponse createApplicationVersion(final String applicationName, final CreateApplicationVersionRequest request) {
-        logger.debug("Creating application version for name: {}", applicationName);
+        logger.debug("Creating application version", kv("applicationName", applicationName));
         validateCreateApplicationVersion(applicationName, request);
 
         final MobileAppVersionEntity entity = convert(request);
@@ -320,7 +322,7 @@ public class AdminService {
     }
 
     public void deleteApplicationVersion(final String applicationName, final Long id) {
-        logger.debug("Deleting application version name: {}, ID: {}", applicationName, id);
+        logger.debug("Deleting application version", kv("applicationName", applicationName), kv("id", id));
         mobileAppVersionRepository.deleteById(id);
     }
 
@@ -332,20 +334,20 @@ public class AdminService {
     @Transactional(readOnly = true)
     public TextDetailResponse textDetail(final String key, final String language) {
         final var id = new LocalizedTextEntity.LocalizedTextId(key, language);
-        logger.debug("Looking for text ID: {}", id);
+        logger.debug("Looking for text", kv("id", id));
         return convert(localizedTextRepository.findById(id)
                 .orElseThrow(() -> new ConstraintViolationException("Text not found, ID: " + id, Collections.emptySet())));
     }
 
     public TextDetailResponse createText(final CreateTextRequest request) {
-        logger.debug("Creating text key: {}, language: {}", request.getMessageKey(), request.getLanguage());
+        logger.debug("Creating text", kv("key", request.getMessageKey()), kv("language", request.getLanguage()));
         final var result = localizedTextRepository.save(convert(request));
         return convert(result);
     }
 
     public void deleteText(final String key, final String language) {
         final var id = new LocalizedTextEntity.LocalizedTextId(key, language);
-        logger.debug("Deleting text ID: {}", id);
+        logger.debug("Deleting text", kv("id", id));
         localizedTextRepository.deleteById(id);
     }
 

--- a/src/main/java/com/wultra/app/mobileutilityserver/rest/service/CryptographicOperationsService.java
+++ b/src/main/java/com/wultra/app/mobileutilityserver/rest/service/CryptographicOperationsService.java
@@ -42,6 +42,8 @@ import org.bouncycastle.openssl.jcajce.JcaPEMWriter;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
+import static net.logstash.logback.argument.StructuredArguments.kv;
+
 import com.wultra.security.powerauth.crypto.lib.config.PowerAuthConfiguration;
 import com.wultra.security.powerauth.crypto.lib.generator.KeyGenerator;
 import com.wultra.security.powerauth.crypto.lib.model.exception.CryptoProviderException;
@@ -91,8 +93,7 @@ public class CryptographicOperationsService {
         try {
             return SecureRandom.getInstance(SECURE_RANDOM_ALGORITHM_NAME, PowerAuthConfiguration.CRYPTO_PROVIDER_NAME);
         } catch (NoSuchAlgorithmException | NoSuchProviderException e) {
-            logger.warn("Unable to register strong random number generator: {}", e.getMessage());
-            logger.debug("Exception details: ", e);
+            logger.warn("Unable to register strong random number generator", e);
             return new SecureRandom();
         }
     }

--- a/src/main/java/com/wultra/app/mobileutilityserver/rest/service/MobileAppService.java
+++ b/src/main/java/com/wultra/app/mobileutilityserver/rest/service/MobileAppService.java
@@ -33,6 +33,8 @@ import org.springframework.dao.IncorrectResultSizeDataAccessException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import static net.logstash.logback.argument.StructuredArguments.kv;
+
 import java.util.Locale;
 import java.util.Optional;
 import java.util.function.Supplier;
@@ -105,7 +107,7 @@ public class MobileAppService {
         final int majorSystemVersion = new DefaultArtifactVersion(request.getSystemVersion()).getMajorVersion();
         final Optional<MobileAppVersionEntity> applicationVersion = findApplicationVersion(applicationName, platform, majorSystemVersion);
         if (applicationVersion.isEmpty()) {
-            logger.info("Application name: {}, platform: {} is not configured, returning OK", applicationName, platform);
+            logger.info("Application version not configured, returning OK", kv("applicationName", applicationName), kv("platform", platform));
             return VerifyVersionResult.ok();
         }
 
@@ -123,10 +125,10 @@ public class MobileAppService {
         final Optional<MobileAppVersionEntity> applicationVersion = findFailSafe(() ->
                 mobileAppVersionRepository.findFirstByApplicationNameAndPlatformAndMajorOsVersion(applicationName, platform, majorSystemVersion));
         if (applicationVersion.isPresent()) {
-            logger.debug("Found exact match for applicationName: {}, platform: {} and majorSystemVersion: {}", applicationName, platform, majorSystemVersion);
+            logger.debug("Found exact match for application version", kv("applicationName", applicationName), kv("platform", platform), kv("majorSystemVersion", majorSystemVersion));
             return applicationVersion;
         }
-        logger.debug("Looking for applicationName: {} and platform: {} without specific majorSystemVersion.", applicationName, platform);
+        logger.debug("Looking for application version without specific majorSystemVersion", kv("applicationName", applicationName), kv("platform", platform));
         return findFailSafe(() -> mobileAppVersionRepository.findFirstByApplicationNameAndPlatform(applicationName, platform));
     }
 
@@ -135,8 +137,7 @@ public class MobileAppService {
             return supplier.get();
         } catch (IncorrectResultSizeDataAccessException e) {
             // should be validated by admin API, but fail-safe routine, because unique index not working due to nullable major OS version
-            logger.warn("Misconfigured application versions, got more results: {}", e.getMessage());
-            logger.debug("Misconfigured application versions, got more results", e);
+            logger.warn("Misconfigured application versions, got more results", e);
             return Optional.empty();
         }
     }
@@ -174,7 +175,7 @@ public class MobileAppService {
             return localizedText.get().getText();
         }
 
-        logger.debug("Localized text key: {} not found for locale: {}, falling back to EN", key, locale);
+        logger.debug("Localized text key not found for locale, falling back to EN", kv("key", key), kv("locale", locale));
         return localizedTextRepository.findByMessageKeyAndLocale(key, Locale.ENGLISH)
                 .map(LocalizedTextEntity::getText)
                 .orElse(null);

--- a/src/main/resources/application-dev.properties
+++ b/src/main/resources/application-dev.properties
@@ -1,0 +1,1 @@
+logging.config=classpath:logback-dev.xml

--- a/src/main/resources/logback-dev.xml
+++ b/src/main/resources/logback-dev.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Wultra Mobile Utility Server
+  ~ Copyright (C) 2026 Wultra s.r.o.
+  ~
+  ~ This program is free software: you can redistribute it and/or modify
+  ~ it under the terms of the GNU Affero General Public License as
+  ~ published by the Free Software Foundation, either version 3 of the
+  ~ License, or (at your option) any later version.
+  ~
+  ~ This program is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  ~ GNU Affero General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Affero General Public License
+  ~ along with this program.  If not, see <https://www.gnu.org/licenses/>.
+  -->
+
+<configuration>
+    <conversionRule conversionWord="sa" converterClass="com.wultra.core.logging.logback.StructuredArgumentsConverter"/>
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%sa%n</pattern>
+        </encoder>
+    </appender>
+    <root level="INFO">
+        <appender-ref ref="STDOUT"/>
+    </root>
+</configuration>

--- a/src/test/resources/logback-test.xml
+++ b/src/test/resources/logback-test.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Wultra Mobile Utility Server
+  ~ Copyright (C) 2026 Wultra s.r.o.
+  ~
+  ~ This program is free software: you can redistribute it and/or modify
+  ~ it under the terms of the GNU Affero General Public License as
+  ~ published by the Free Software Foundation, either version 3 of the
+  ~ License, or (at your option) any later version.
+  ~
+  ~ This program is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  ~ GNU Affero General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Affero General Public License
+  ~ along with this program.  If not, see <https://www.gnu.org/licenses/>.
+  -->
+
+<configuration>
+    <conversionRule conversionWord="sa" converterClass="com.wultra.core.logging.logback.StructuredArgumentsConverter"/>
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%sa%n</pattern>
+        </encoder>
+    </appender>
+    <root level="INFO">
+        <appender-ref ref="STDOUT"/>
+    </root>
+</configuration>


### PR DESCRIPTION
## Summary

Applies L6/L7/L8 structured logging improvements across all service classes.

### Changes

**L6 — Contextual IDs wrapped with `kv()`**
- `AppInitializationController`: `applicationName`
- `ResponseSignFilter`: `appName`
- `HttpHeaders`: `challengeHeader`
- `AdminService`: `appName`, `domain`, `applicationName`, `id`, `key`, `language`
- `MobileAppService`: `applicationName`, `platform`, `majorSystemVersion`, `key`, `locale`

**L7 — Action/state pattern in `AdminService`**
- Certificate operations now emit `kv("action", ...)` + `kv("state", ...)` fields

**L8 — Consolidated double-logging**
- `ExceptionHandlingControllerAdvice`: 12 warn+debug pairs → single log with exception as last arg
- `CryptographicOperationsService`: 1 warn+debug pair merged
- `HttpHeaders`: warn+debug pair merged
- `MobileAppService`: warn+debug pair merged

**Infrastructure**
- Bump `wultra-core.version`: `2.1.0` → `2.2.0-SNAPSHOT`
- Add `logging-support` compile dependency
- Add `logback-dev.xml` (text output, local dev)
- Add `logback-test.xml` (text output, tests)
- Add `application-dev.properties` activating `logback-dev.xml`

Closes #496