### PR TITLE
Fix missing message field in Elasticsearch for structured (kv) logs (#513)

### DIFF
--- a/src/main/java/com/wultra/app/mobileutilityserver/rest/service/AdminService.java
+++ b/src/main/java/com/wultra/app/mobileutilityserver/rest/service/AdminService.java
@@ -150,7 +150,7 @@ public class AdminService {
             for (CertificateEntity cert : certificateEntityOptional) {
                 if (fingerprint.equalsIgnoreCase(cert.getFingerprint())) {
                     final CertificateDetailResponse response = certificateConverter.convertCertificateDetailResponse(cert);
-                    logger.info("", kv("action", "addOrRefreshCertificate"), kv("state", "noChange"), kv("appName", appName), kv("domain", domain));
+                    logger.info("Add or refresh certificate no change", kv("action", "addOrRefreshCertificate"), kv("state", "noChange"), kv("appName", appName), kv("domain", domain));
                     return response;
                 }
             }
@@ -175,7 +175,7 @@ public class AdminService {
         final CertificateEntity savedCertificateEntity = certificateRepository.save(certificateEntity);
 
         final CertificateDetailResponse response = certificateConverter.convertCertificateDetailResponse(savedCertificateEntity);
-        logger.info("", kv("action", "addOrRefreshCertificate"), kv("state", "succeeded"), kv("appName", appName), kv("domain", domain));
+        logger.info("Add or refresh certificate succeeded", kv("action", "addOrRefreshCertificate"), kv("state", "succeeded"), kv("appName", appName), kv("domain", domain));
         return response;
     }
 
@@ -216,7 +216,7 @@ public class AdminService {
 
         final X509Certificate cert = fetchCertificate(domain);
         final String certPem = cryptographicOperationsService.certificateToPem(cert);
-        logger.info("", kv("action", "createCertificate"), kv("state", "initiated"), kv("appName", appName), kv("domain", domain));
+        logger.info("Create certificate initiated", kv("action", "createCertificate"), kv("state", "initiated"), kv("appName", appName), kv("domain", domain));
 
         final CreateApplicationCertificatePemRequest innerRequest = new CreateApplicationCertificatePemRequest();
         innerRequest.setDomain(domain);


### PR DESCRIPTION
## Summary

Structured `kv(...)` log calls in `AdminService` passed an empty message string (`logger.info("", kv(...))`). Because the Logstash encoder is configured with `<omitEmptyFields>true</omitEmptyFields>`, the empty `message` field was dropped and indexed as `null` in Elasticsearch.

This adds concise, human-readable messages derived from `action` + `state`, while keeping the structured `kv(...)` arguments unchanged. No logback/encoder config change required.

## Changes (`AdminService.java`)

- `addOrRefreshCertificate` / `noChange` → "Add or refresh certificate no change"
- `addOrRefreshCertificate` / `succeeded` → "Add or refresh certificate succeeded"
- `createCertificate` / `initiated` → "Create certificate initiated"

Follows the convention from wultra/enrollment-server#1820.

Closes #513