### PR TITLE
docs #511: consolidate changelog and add copilot instructions

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,69 @@
+# Copilot Instructions — mobile-utility-server
+
+This file documents the changelog conventions for the `mobile-utility-server` repository,
+following the Wultra PowerAuth ecosystem standard.
+
+---
+
+## Changelog
+
+`CHANGELOG.md` lives at the **repo root**. Update it as part of every PR — before creating
+the PR, not after merge.
+
+### Format
+
+Strictly follows [Keep a Changelog 1.1.0](https://keepachangelog.com/en/1.1.0/) and
+[Semantic Versioning](https://semver.org/spec/v2.0.0.html):
+
+```markdown
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+- New feature description [(#N)](https://github.com/wultra/mobile-utility-server/issues/N)
+
+### Changed
+- Changed behaviour description [(#N)](...)
+
+### Fixed
+- Bug fix description [(#N)](...)
+
+## [1.2.3] - 2025-03-01
+
+### Added
+- ...
+
+[unreleased]: https://github.com/wultra/mobile-utility-server/compare/1.2.3...HEAD
+[1.2.3]: https://github.com/wultra/mobile-utility-server/compare/1.2.2...1.2.3
+```
+
+**Change-type subsections** (use only those that apply):
+
+- `Added` — new features
+- `Changed` — changes in existing functionality
+- `Deprecated` — soon-to-be-removed features
+- `Removed` — removed features
+- `Fixed` — bug fixes
+- `Security` — security vulnerability fixes
+
+### Rules
+
+- The header must mention both [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
+  and [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+- Always add new entries under the `## [Unreleased]` section at the top.
+- On release: rename `## [Unreleased]` to `## [x.y.z] - YYYY-MM-DD` (ISO 8601 date), add a
+  fresh empty `## [Unreleased]` above it, update the `[unreleased]` reference link, and add
+  the new version's compare link at the bottom.
+- Versions and sections must be linkable via reference-style links at the bottom of the file.
+- Each entry: `- <Description starting with a verb> [(#N)](url)` — link to the **issue**,
+  not the PR.
+- Descriptions should be human-readable, not raw commit messages (e.g. "Fixed NPE when
+  application list is empty", not "fix #811: add missing import").
+- Skip the changelog update only for changes with no user-visible impact (e.g. pure
+  CI/tooling changes).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,15 @@
 # Changelog
 
+All notable changes to this project will be documented in this file.
 
-## 2.1.0 (TBA)
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
 
 ### Changed
 
-- Upgraded Docker base image to `ibm-semeru-runtimes:open-jdk-25.0.3.0-jre-noble` (OpenJDK 25) [(504)](https://github.com/wultra/mobile-utility-server/issues/504)
-- Migrated to Spring Boot 4 and Jackson 3 [(503)](https://github.com/wultra/mobile-utility-server/issues/503)
+- Upgraded Docker base image to `ibm-semeru-runtimes:open-jdk-25.0.3.0-jre-noble` (OpenJDK 25) [(#504)](https://github.com/wultra/mobile-utility-server/issues/504)
+- Migrated to Spring Boot 4 and Jackson 3 [(#503)](https://github.com/wultra/mobile-utility-server/issues/503)
+
+[unreleased]: https://github.com/wultra/mobile-utility-server/compare/2.0.0...HEAD


### PR DESCRIPTION
🤖
## Description

Aligns `mobile-utility-server` with the Wultra changelog and Copilot conventions defined in the parent epic (wultra/tasklist#986).

- Rewrote `CHANGELOG.md` to **strictly** follow [Keep a Changelog 1.1.0](https://keepachangelog.com/en/1.1.0/):
  - Added the canonical header referencing both Keep a Changelog and [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
  - Converted the legacy `## 2.1.0 (TBA)` section into `## [Unreleased] > ### Changed`, preserving the existing entries and normalizing issue links to `[(#N)](…/issues/N)`.
  - Added a reference-style `[unreleased]` compare link (base tag `2.0.0`).
- Added `.github/copilot-instructions.md` documenting the changelog conventions with this repository's name and issue URLs.

## Motivation and Context

Standardizes the changelog format and documents the maintenance conventions so future entries stay consistent across the Wultra PowerAuth ecosystem.

## Closes

Closes #511
